### PR TITLE
修复 iOS 18.0+ 新增的 Expression 与 sqlite.swift Expression 冲突导致的编译失败

### DIFF
--- a/Shared/Database/TCategory.swift
+++ b/Shared/Database/TCategory.swift
@@ -14,13 +14,13 @@ struct TCategory: Identifiable, Hashable {
 
     static let table = Table("category")
 
-    static let id = Expression<String>("id")
-    static let name = Expression<String>("name")
-    static let folder = Expression<String>("folder")
-    static let isSubFolder = Expression<Bool>("isSubFolder")
-    static let order = Expression<Int?>("order")
+    static let id = SQLExpr<String>("id")
+    static let name = SQLExpr<String>("name")
+    static let folder = SQLExpr<String>("folder")
+    static let isSubFolder = SQLExpr<Bool>("isSubFolder")
+    static let order = SQLExpr<Int?>("order")
 
-    static let group = Expression<String?>("group")
+    static let group = SQLExpr<String?>("group")
     
     let id: UUID
     let name: String

--- a/Shared/Database/TLaw.swift
+++ b/Shared/Database/TLaw.swift
@@ -4,20 +4,20 @@ import Foundation
 struct TLaw: Identifiable {
     static let table = Table("law")
 
-    static let id = Expression<String>("id")
-    static let name = Expression<String>("name")
-    static let categoryID = Expression<String>("category_id")
-    static let expired = Expression<Bool>("expired")
-    static let level = Expression<String>("level")
+    static let id = SQLExpr<String>("id")
+    static let name = SQLExpr<String>("name")
+    static let categoryID = SQLExpr<String>("category_id")
+    static let expired = SQLExpr<Bool>("expired")
+    static let level = SQLExpr<String>("level")
 
-    static let filename = Expression<String?>("filename")
-    static let publish = Expression<String?>("publish")
-    static let order = Expression<Int?>("order")
-    static let subtitle = Expression<String?>("subtitle")
-    static let valid_from = Expression<String?>("valid_from")
+    static let filename = SQLExpr<String?>("filename")
+    static let publish = SQLExpr<String?>("publish")
+    static let order = SQLExpr<Int?>("order")
+    static let subtitle = SQLExpr<String?>("subtitle")
+    static let valid_from = SQLExpr<String?>("valid_from")
 
-    static let ver = Expression<Int>("ver")
-    static let tags = Expression<String?>("tags")
+    static let ver = SQLExpr<Int>("ver")
+    static let tags = SQLExpr<String?>("tags")
 
     let id: UUID
     let name: String

--- a/Shared/Manager/Law/LawDatabase.swift
+++ b/Shared/Manager/Law/LawDatabase.swift
@@ -23,11 +23,11 @@ class LawDatabase {
         sqlite3_close(self.connection.handle)
     }
     
-    func getCategory(predicate: Expression<Bool>? = nil) async -> TCategory? {
+    func getCategory(predicate: SQLExpr<Bool>? = nil) async -> TCategory? {
         return await self.getCategories(predicate: predicate).first
     }
 
-    func getCategories(predicate: Expression<Bool>? = nil) async -> [TCategory] {
+    func getCategories(predicate: SQLExpr<Bool>? = nil) async -> [TCategory] {
         var rows = AnySequence<Row>([])
 
         var query = TCategory.table
@@ -46,7 +46,7 @@ class LawDatabase {
         return rows.map { TCategory.create(row: $0, laws: []) }
     }
 
-    func getLaws(predicate: Expression<Bool>? = nil) async -> [TLaw] {
+    func getLaws(predicate: SQLExpr<Bool>? = nil) async -> [TLaw] {
         var rows = AnySequence<Row>([])
 
         var query = TLaw.table

--- a/Shared/Manager/Law/LawManager.swift
+++ b/Shared/Manager/Law/LawManager.swift
@@ -79,7 +79,7 @@ final class LawManager: ObservableObject {
     }
 
     // 取所有 TLaws
-    private func queryLaws(predicate: Expression<Bool>? = nil) async -> [TLaw] {
+    private func queryLaws(predicate: SQLExpr<Bool>? = nil) async -> [TLaw] {
         var ret = [TLaw]()
         for db in dbs {
             let laws = await db.getLaws(predicate: predicate)

--- a/iOS/Utils/TypealiasUtils.swift
+++ b/iOS/Utils/TypealiasUtils.swift
@@ -1,0 +1,11 @@
+//
+//  TypealiasUtils.swift
+//  law.handbook
+//
+//  Created by lihui on 2025/5/2.
+//
+
+import SQLite
+
+typealias SQLExpr<T> = SQLite.Expression<T>
+

--- a/law.handbook.xcodeproj/project.pbxproj
+++ b/law.handbook.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		90F7F99B29C6F1C700F9FEC2 /* HomeCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F7F99A29C6F1C700F9FEC2 /* HomeCardView.swift */; };
 		90F7F99D29C6F8C500F9FEC2 /* HomeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F7F99C29C6F8C500F9FEC2 /* HomeBannerView.swift */; };
 		90F7F99F29C7269700F9FEC2 /* HomeCasesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F7F99E29C7269700F9FEC2 /* HomeCasesView.swift */; };
+		9CC5E3642DC4502300DDD088 /* TypealiasUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC5E3632DC4501300DDD088 /* TypealiasUtils.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -274,6 +275,7 @@
 		90F7F99A29C6F1C700F9FEC2 /* HomeCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCardView.swift; sourceTree = "<group>"; };
 		90F7F99C29C6F8C500F9FEC2 /* HomeBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeBannerView.swift; sourceTree = "<group>"; };
 		90F7F99E29C7269700F9FEC2 /* HomeCasesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCasesView.swift; sourceTree = "<group>"; };
+		9CC5E3632DC4501300DDD088 /* TypealiasUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypealiasUtils.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -583,6 +585,7 @@
 		90E8357C2931CD9300519E23 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				9CC5E3632DC4501300DDD088 /* TypealiasUtils.swift */,
 				905B83D527F83BFD00F951E9 /* ImageUtils.swift */,
 				90193EFF27F5A376008CF0A6 /* Consts.swift */,
 				90E8357D2931CD9C00519E23 /* Review.swift */,
@@ -885,6 +888,7 @@
 				9080B83F2A20A15500F45A9B /* MetadataManager.swift in Sources */,
 				901D199F2847565C00999AE6 /* QRCode.swift in Sources */,
 				90E835DE2938D30A00519E23 /* ShareButton.swift in Sources */,
+				9CC5E3642DC4502300DDD088 /* TypealiasUtils.swift in Sources */,
 				90E8357B2931CD6500519E23 /* String.swift in Sources */,
 				9047E80E29B0561200BC02E4 /* ChatView.swift in Sources */,
 				90D4CDAC2862F627006DB8AC /* SearchHistoryViewModel.swift in Sources */,


### PR DESCRIPTION
修复 iOS 18.0+ 新增的 Expression 与 sqlite.swift Expression 冲突导致的编译失败